### PR TITLE
Fix that getting wrong hours from modified duration

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func format(d time.Duration) string {
 	d -= m * time.Minute
 	s := d / time.Second
 
-	if d.Hours() < 1 {
+	if h < 1 {
 		return fmt.Sprintf("%02d:%02d", m, s)
 	}
 	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)


### PR DESCRIPTION
`d` has been modified, so it does not equal original value. So `d.Hours()` always returns 0 because the hours part was already subtracted from `d`.

```
h := d / time.Hour
d -= h * time.Hour
```

It should use `h` instead.