### PR TITLE
adding newline to the end of usage text so the terminal would return …

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,8 @@ const (
 	usage = `usage:
 countdown 25s
 countdown 1m50s
-countdown 2h45m50s`
+countdown 2h45m50s
+`
 	tick = time.Second
 )
 


### PR DESCRIPTION
…to new line

before:

	$ countdown
	usage:
	countdown 25s
	countdown 1m50s
	countdown 2h45m50s$

after:

	$ countdown
	usage:
	countdown 25s
	countdown 1m50s
	countdown 2h45m50s
	$
