### PR TITLE
Update README.md with correct installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ countdown 1m30s && say "Hello, world"
 ## Install
 
 ```bash
-go get github.com/antonmedv/countdown
+go install github.com/antonmedv/countdown
 ```
 
 ## License


### PR DESCRIPTION
`go get` is now deprecated in favor of `go install` - https://go.dev/doc/go-get-install-deprecation.