### PR TITLE
Fix termbox in tmux

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,6 +146,11 @@ func main() {
 		os.Exit(2)
 	}
 
+	term := os.Getenv("TERM")
+	if (len(term) >= 4 && term[0:4] == "tmux") {
+		os.Setenv("TERM", "xterm-color")
+	}
+
 	timeLeft, err := getKitchenTimeDuration(os.Args[1])
 
 	if err != nil {


### PR DESCRIPTION
Fix termbox in tmux by setting TERM environment variable to "xterm-color".

Mine happens to be `tmux-256color`, which termbox doesn't support.